### PR TITLE
Mods to show query results as html table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 db.pickle
 wordcloud.png
 pdfs/
+.gitignore
+results/


### PR DESCRIPTION
Added a mod to the query functionality such that the titles, publication dates and clickable arXiv links of papers fetched from a given query are saved as an HTML table. The table is also opened in the system's primary browser. Note: This method will not work as is if an alias is being used to run oh-my-dl from terminal. In the current version, please use it from the parent directory of the script.